### PR TITLE
Bump runtime to 21.08

### DIFF
--- a/com.avocode.Avocode.yml
+++ b/com.avocode.Avocode.yml
@@ -1,9 +1,9 @@
 id: com.avocode.Avocode
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 base: org.electronjs.Electron2.BaseApp
-base-version: '19.08'
+base-version: '21.08'
 finish-args:
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
I didn't bump the application version since there is https://github.com/flathub/com.avocode.Avocode/pull/59 already.

Ping @amikha1lov, please review when you have time, thanks!